### PR TITLE
Upgrade controller runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 vendor/
 .idea
+
+### VisualStudioCode ###
+.vscode/*
+.history

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 vendor/
+.idea
+
+### VisualStudioCode ###
+.vscode/*
+.history

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+  - 1.13.x
+before_install:
+  - go get -u github.com/golang/dep/cmd/dep
+  - dep ensure -v
+script:
+  - go test -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
 language: go
+go:
+  - 1.13.x
+before_install:
+  - go get -u github.com/golang/dep/cmd/dep
+  - dep ensure -v
+script:
+  - go test -v

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,30 @@
 
 
 [[projects]]
+  digest = "1:9f3b30d9f8e0d7040f729b82dcbc8f0dead820a133b3147ce355fc451f32d761"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:ac425d784b13d49b37a5bbed3ce022677f8f3073b216f05d6adcb9303e27fa0f"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "026c730a0dcc5d11f93f1cf1cc65b01247ea7b6f"
+  version = "v4.5.0"
+
+[[projects]]
   digest = "1:edd2fa4578eb086265db78a9201d15e76b298dfd0d5c379da83e9c61712cf6df"
   name = "github.com/go-logr/logr"
   packages = ["."]
@@ -18,18 +42,18 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:b7a8552c62868d867795b63eaf4f45d3e92d36db82b428e680b9c95a8c33e5b1"
+  digest = "1:582e25eccee928dc12416ea4c23b6dae8f3b5687730632aa1473ebebe80a2359"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
     "sortkeys",
   ]
   pruneopts = "UT"
-  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
-  version = "v0.5"
+  revision = "5628607bb4c51c3157aacc3a50f0ab707582b805"
+  version = "v1.3.1"
 
 [[projects]]
-  digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
+  digest = "1:f5ce1529abc1204444ec73779f44f94e2fa8fcdb7aca3c355b0c95947e4005c6"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -39,26 +63,19 @@
     "ptypes/timestamp",
   ]
   pruneopts = "UT"
-  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
-  version = "v1.1.0"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
 
 [[projects]]
-  digest = "1:0bfbe13936953a98ae3cfe8ed6670d396ad81edf069a806d2f6515d7bb6950df"
-  name = "github.com/google/btree"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
-  version = "v1.0.0"
-
-[[projects]]
-  digest = "1:41bfd4219241b7f7d6e6fdb13fc712576f1337e68e6b895136283b76928fdd66"
+  digest = "1:a6181aca1fd5e27103f9a920876f29ac72854df7345a39f3b01e61c8c94cc8af"
   name = "github.com/google/gofuzz"
   packages = ["."]
   pruneopts = "UT"
-  revision = "44d81051d367757e1c7c6a5a86423ece9afcf63c"
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:75eb87381d25cc75212f52358df9c3a2719584eaa9685cd510ce28699122f39d"
+  digest = "1:ca4524b4855ded427c7003ec903a5c854f37e7b1e8e2a93277243462c5b753a8"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
@@ -66,25 +83,16 @@
     "extensions",
   ]
   pruneopts = "UT"
-  revision = "0c5108395e2debce0d731cf0287ddf7242066aba"
+  revision = "ab0dd09aa10e2952b28e12ecd35681b20463ebab"
+  version = "v0.3.1"
 
 [[projects]]
-  digest = "1:878f0defa9b853f9acfaf4a162ba450a89d0050eff084f9fe7f5bd15948f172a"
-  name = "github.com/gregjones/httpcache"
-  packages = [
-    ".",
-    "diskcache",
-  ]
-  pruneopts = "UT"
-  revision = "787624de3eb7bd915c329cba748687a3b22666a6"
-
-[[projects]]
-  digest = "1:eaefc85d32c03e5f0c2b88ea2f79fce3d993e2c78316d21319575dd4ea9153ca"
+  digest = "1:beb5b4f42a25056f0aa291b5eadd21e2f2903a05d15dfe7caf7eaee7e12fa972"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
-  version = "1.1.4"
+  revision = "03217c3e97663914aec3faafde50d081f197a0a2"
+  version = "v1.1.8"
 
 [[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
@@ -95,47 +103,47 @@
   version = "1.0.3"
 
 [[projects]]
-  digest = "1:c56ad36f5722eb07926c979d5e80676ee007a9e39e7808577b9d87ec92b00460"
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "94122c33edd36123c84d5368cfb2b69df93a0ec8"
-  version = "v1.0.1"
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
-  name = "github.com/petar/GoLLRB"
-  packages = ["llrb"]
-  pruneopts = "UT"
-  revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
-
-[[projects]]
-  digest = "1:0e7775ebbcf00d8dd28ac663614af924411c868dca3d5aa762af0fae3808d852"
-  name = "github.com/peterbourgon/diskv"
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
+  name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
-  version = "v2.0.1"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
-  digest = "1:777e729b475d3895c7229552aa10076f0d177daf37c0a72258006d046d329960"
+  digest = "1:c708d00d1097e62bf4f3a72f239efa7dafc257581421b0b7d3789e1ff5299f30"
   name = "go.uber.org/atomic"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4e336646b2ef9fc6e47be8e21594178f98e5ebcf"
-  version = "v1.2.0"
+  revision = "40ae6a40a970ef4cdbffa7b24b280e316db8accc"
+  version = "v1.5.1"
 
 [[projects]]
-  digest = "1:60bf2a5e347af463c42ed31a493d817f8a72f102543060ed992754e689805d1a"
+  digest = "1:e6d88834deb4e35eb998c74f4d042db6ccecaaf62c0f6d57905852800994af00"
   name = "go.uber.org/multierr"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
-  version = "v1.1.0"
+  revision = "824d08f79702fe5f54aca8400aa0d754318786e7"
+  version = "v1.4.0"
 
 [[projects]]
-  digest = "1:c52caf7bd44f92e54627a31b85baf06a68333a196b3d8d241480a774733dcf8b"
+  branch = "master"
+  digest = "1:3032e90a153750ea149f68bf081f97ca738f041fba45c41c80737f572ffdf2f4"
+  name = "go.uber.org/tools"
+  packages = ["update-license"]
+  pruneopts = "UT"
+  revision = "2cfd321de3ee5d5f8a5fda2521d1703478334d98"
+
+[[projects]]
+  digest = "1:260048b6193e304ee294452a9e3410c474e3ce187248c7e2e4a2631207386f74"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -146,50 +154,64 @@
     "zapcore",
   ]
   pruneopts = "UT"
-  revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
-  version = "v1.9.1"
-
-[[projects]]
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
-  name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
-  pruneopts = "UT"
-  revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
+  revision = "33e58d4d0120aa28d4df84cd244838c490846c9d"
+  version = "v1.13.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:b8c5023d876c0e40eca8729fb4516dcb62887e11524de5a38de8a2067b69a4ec"
+  digest = "1:bbe51412d9915d64ffaa96b51d409e070665efc5194fcf145c4a27d4133107a4"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  pruneopts = "UT"
+  revision = "e9b2fee46413994441b28dfca259d911d963dfed"
+
+[[projects]]
+  branch = "master"
+  digest = "1:334b27eac455cb6567ea28cd424230b07b1a64334a2f861a8075ac26ce10af43"
+  name = "golang.org/x/lint"
+  packages = [
+    ".",
+    "golint",
+  ]
+  pruneopts = "UT"
+  revision = "fdd1cda4f05fd1fd86124f0ef9ce31a0b72c8448"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e4a92f168e339bc2e697401a883588748fa58e0dd3ae14160f9bd890ca37382d"
   name = "golang.org/x/net"
   packages = [
     "context",
+    "context/ctxhttp",
     "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
   ]
   pruneopts = "UT"
-  revision = "4829fb13d2c62012c17688fa7f629f371014946d"
+  revision = "c0dbc17a35534bf2e581d7a942408dc936316da4"
 
 [[projects]]
-  digest = "1:9359217acc6040b4be710ce34473acef28023ad39bfafecea34ffaea7f1e1890"
+  branch = "master"
+  digest = "1:55d36eb35766a3f105fa36cfb2faf053cc33c019108a6adee799c4e7d59d62b2"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
+  revision = "858c2ad4c8b6c5d10852cb89079f6ca1c7309787"
 
 [[projects]]
   branch = "master"
-  digest = "1:656ce95b4cdf841c00825f4cb94f6e0e1422d7d6faaf3094e94cd18884a32251"
+  digest = "1:472d3f5adc36e1c0b9120bc3830d692a090134aa5461335f39caabd0fdb7feac"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "a129542de9ae0895210abff9c95d67a1f33cb93d"
+  revision = "ac6580df4449443a05718fd7858c1f91ad5f8d20"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
@@ -217,14 +239,49 @@
   version = "v0.3.2"
 
 [[projects]]
-  digest = "1:d37b0ef2944431fe9e8ef35c6fffc8990d9e2ca300588df94a6890f3649ae365"
+  branch = "master"
+  digest = "1:a2f668c709f9078828e99cb1768cb02e876cb81030545046a32b54b2ac2a9ea8"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "UT"
-  revision = "f51c12702a4d776e4c1fa9b0fabab841babae631"
+  revision = "555d28b269f0569763d25dbe1a237ae74c6bcc82"
 
 [[projects]]
-  digest = "1:6eb6e3b6d9fffb62958cf7f7d88dbbe1dd6839436b0802e194c590667a40412a"
+  branch = "master"
+  digest = "1:5a4e76bcf49c1e4f67345281554ea7dfb1df0f8bff4677610b373fa1d31855f1"
+  name = "golang.org/x/tools"
+  packages = [
+    "go/analysis",
+    "go/analysis/passes/inspect",
+    "go/ast/astutil",
+    "go/ast/inspector",
+    "go/buildutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/objectpath",
+    "go/types/typeutil",
+    "internal/fastwalk",
+    "internal/gopathwalk",
+    "internal/semver",
+  ]
+  pruneopts = "UT"
+  revision = "1bcf67c9cb49ca7dff98883ae7d19d6dd2288ae3"
+
+[[projects]]
+  branch = "master"
+  digest = "1:918a46e4a2fb83df33f668f5a6bd51b2996775d073fce1800d3ec01b0a5ddd2b"
+  name = "golang.org/x/xerrors"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = "UT"
+  revision = "9bdfabe68543c54f90421aeb9a60ef8061b5b544"
+
+[[projects]]
+  digest = "1:e0a1881f9e0564bebdeac98c75e59f07acdde6ed3a5396e0e613eaad31194866"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -236,30 +293,63 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "54a98f90d1c46b7731eb8fb305d2a321c30ef610"
-  version = "v1.5.0"
+  revision = "971852bfffca25b069c31162ae8f247a3dba083b"
+  version = "v1.6.5"
 
 [[projects]]
-  digest = "1:ef72505cf098abdd34efeea032103377bec06abb61d8a06f002d5d296a4b1185"
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
-  version = "v0.9.0"
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
 
 [[projects]]
-  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
+  digest = "1:b75b3deb2bce8bc079e16bb2aecfe01eb80098f5650f9e93e5643ca8b7b73737"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
-  version = "v2.2.2"
+  revision = "1f64d6156d11335c3f22d9330b0ad14fc1e789ce"
+  version = "v2.2.7"
 
 [[projects]]
-  digest = "1:0d299a04c6472e4458461d7034c76d014cc6f632a3262cbf21d123b19ce13e65"
+  digest = "1:131158a88aad1f94854d0aa21a64af2802d0a470fb0f01cb33c04fafd2047111"
+  name = "honnef.co/go/tools"
+  packages = [
+    "arg",
+    "cmd/staticcheck",
+    "config",
+    "deprecated",
+    "facts",
+    "functions",
+    "go/types/typeutil",
+    "internal/cache",
+    "internal/passes/buildssa",
+    "internal/renameio",
+    "internal/sharedcheck",
+    "lint",
+    "lint/lintdsl",
+    "lint/lintutil",
+    "lint/lintutil/format",
+    "loader",
+    "printf",
+    "simple",
+    "ssa",
+    "ssautil",
+    "staticcheck",
+    "staticcheck/vrp",
+    "stylecheck",
+    "unused",
+    "version",
+  ]
+  pruneopts = "UT"
+  revision = "afd67930eec2a9ed3e9b19f684d17a062285f16a"
+  version = "2019.2.3"
+
+[[projects]]
+  digest = "1:d89afbf3588e87d2c9e6efdd5528d249b32d23a12fbd7ec324f3cb373c6fb76c"
   name = "k8s.io/api"
   packages = [
-    "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
     "apps/v1beta1",
@@ -276,15 +366,20 @@
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
+    "coordination/v1",
     "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
     "networking/v1",
+    "networking/v1beta1",
+    "node/v1alpha1",
+    "node/v1beta1",
     "policy/v1beta1",
     "rbac/v1",
     "rbac/v1alpha1",
     "rbac/v1beta1",
+    "scheduling/v1",
     "scheduling/v1alpha1",
     "scheduling/v1beta1",
     "settings/v1alpha1",
@@ -293,11 +388,11 @@
     "storage/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "05914d821849570fba9eacfb29466f2d8d3cd229"
-  version = "kubernetes-1.13.1"
+  revision = "bd6ac527cfd24ad928f66798231e5bcf7f37321b"
+  version = "kubernetes-1.15.4"
 
 [[projects]]
-  digest = "1:350c76315d8fbafb7e6750c9abb76ab3df9b0bcd4d5729530cb1edb210c5cc33"
+  digest = "1:f5ba3cec00bacba4e821585d0361c4451f38f36b2326158d93f8588514e9d5bf"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -306,7 +401,6 @@
     "pkg/api/resource",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
-    "pkg/apis/meta/v1beta1",
     "pkg/conversion",
     "pkg/conversion/queryparams",
     "pkg/fields",
@@ -338,11 +432,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
-  revision = "2b1284ed4c93a43499e781493253e2ac5959c4fd"
-  version = "kubernetes-1.13.1"
+  revision = "f2f3a405f61d6c2cdc0d00687c1b5d90de91e9f0"
+  version = "kubernetes-1.15.4"
 
 [[projects]]
-  digest = "1:439f7c74c7fbf4744cbda7690d90a5975c039fdaa47ba7349b0951966ece5200"
+  digest = "1:ff2986eff089917e27d5fbc9982caffb8f092861021d88ca9aba388e17f1b316"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -362,30 +456,41 @@
     "util/cert",
     "util/connrotation",
     "util/flowcontrol",
-    "util/integer",
+    "util/keyutil",
   ]
   pruneopts = "UT"
-  revision = "8d9ed539ba3134352c586810e749e58df4e94e4f"
-  version = "kubernetes-1.13.1"
+  revision = "78d2af792babf2dd937ba2e2a8d99c753a5eda89"
+  version = "v12.0.0"
 
 [[projects]]
-  digest = "1:e2999bf1bb6eddc2a6aa03fe5e6629120a53088926520ca3b4765f77d7ff7eab"
+  digest = "1:93e82f25d75aba18436ad1ac042cb49493f096011f2541075721ed6f9e05c044"
   name = "k8s.io/klog"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8139d8cb77af419532b33dfa7dd09fbc5f1d344f"
+  revision = "2ca9ad30301bf30a8a6e0fa2110db6b8df699a91"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:55997b7c979cdb480e23040db7bf87ebfb8dc3a6c7e8ea3c2aba77440a3e1f0e"
+  branch = "master"
+  digest = "1:8a5e4720aca8a94c876d960a2b86afcaf98e8ded4b5bd7fe42d920806b292c57"
+  name = "k8s.io/utils"
+  packages = ["integer"]
+  pruneopts = "UT"
+  revision = "6ca3b61696b65b0e81f1a39b4937fc2d2994ed6a"
+
+[[projects]]
+  digest = "1:452d006db74468334258fd7e48f86f5ea660e091fa4611bb5e81f6f7d04ad8c9"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/client",
     "pkg/client/apiutil",
+    "pkg/log",
+    "pkg/log/zap",
     "pkg/runtime/log",
   ]
   pruneopts = "UT"
-  revision = "12d98582e72927b6cd0123e2b4e819f9341ce62c"
-  version = "v0.1.10"
+  revision = "d21241119ea4de139f1892ba2f5bc72c96d07f3f"
+  version = "v0.3.0"
 
 [[projects]]
   digest = "1:7719608fe0b52a4ece56c2dde37bedd95b938677d1ab0f84b8a7852e4c59f849"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,14 +24,17 @@
 #   go-tests = true
 #   unused-packages = true
 
-
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.13.1"
+  version = "kubernetes-1.15.4"
 
+[[override]]
+  name = "k8s.io/api"
+  version = "kubernetes-1.15.4"
+  
 [[constraint]]
   name = "sigs.k8s.io/controller-runtime"
-  version = "0.1.10"
+  version = "0.3.0"
 
 [prune]
   go-tests = true

--- a/manifestival.go
+++ b/manifestival.go
@@ -15,6 +15,9 @@ var (
 	log = logf.Log.WithName("manifestival")
 )
 
+// Manifestival allows group application of a set of Kubernetes resources
+// (typically, a set of YAML files, aka a manifest) against a Kubernetes
+// apiserver.
 type Manifestival interface {
 	// Either updates or creates all resources in the manifest
 	ApplyAll() error
@@ -30,6 +33,8 @@ type Manifestival interface {
 	Transform(fns ...Transformer) error
 }
 
+// Manifest tracks a set of concrete resources which should be managed as a
+// group using a Kubernetes client provided by `NewManifest`.
 type Manifest struct {
 	Resources []unstructured.Unstructured
 	client    client.Client
@@ -37,6 +42,10 @@ type Manifest struct {
 
 var _ Manifestival = &Manifest{}
 
+// NewManifest creates a Manifest from a comma-separated set of yaml files or
+// directories (and subdirectories if the `recursive` option is set). The
+// Manifest will be evaluated using the supplied `client` against a particular
+// Kubernetes apiserver.
 func NewManifest(pathname string, recursive bool, client client.Client) (Manifest, error) {
 	log.Info("Reading file", "name", pathname)
 	resources, err := Parse(pathname, recursive)
@@ -46,6 +55,7 @@ func NewManifest(pathname string, recursive bool, client client.Client) (Manifes
 	return Manifest{Resources: resources, client: client}, nil
 }
 
+// ApplyAll updates or creates all resources in the manifest.
 func (f *Manifest) ApplyAll() error {
 	for _, spec := range f.Resources {
 		if err := f.Apply(&spec); err != nil {
@@ -55,6 +65,8 @@ func (f *Manifest) ApplyAll() error {
 	return nil
 }
 
+// Apply updates or creates a particular resource, which does not need to be
+// part of `Resources`, and will not be tracked.
 func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 	current, err := f.Get(spec)
 	if err != nil {
@@ -78,6 +90,7 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 	return nil
 }
 
+// DeleteAll removes all tracked `Resources` in the Manifest.
 func (f *Manifest) DeleteAll(opts ...client.DeleteOptionFunc) error {
 	a := make([]unstructured.Unstructured, len(f.Resources))
 	copy(a, f.Resources)
@@ -95,6 +108,8 @@ func (f *Manifest) DeleteAll(opts ...client.DeleteOptionFunc) error {
 	return nil
 }
 
+// Delete removes the specified objects, which do not need to be registered as
+// `Resources` in the Manifest.
 func (f *Manifest) Delete(spec *unstructured.Unstructured, opts ...client.DeleteOptionFunc) error {
 	current, err := f.Get(spec)
 	if current == nil && err == nil {
@@ -110,6 +125,8 @@ func (f *Manifest) Delete(spec *unstructured.Unstructured, opts ...client.Delete
 	return nil
 }
 
+// Get collects a full resource body (or `nil`) from a partial resource
+// supplied in `spec`.
 func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	key := client.ObjectKey{Namespace: spec.GetNamespace(), Name: spec.GetName()}
 	result := &unstructured.Unstructured{}
@@ -124,6 +141,8 @@ func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructu
 	return result, err
 }
 
+// UpdateChanged recursively merges JSON-style values in `src` into `tgt`.
+// 
 // We need to preserve the top-level target keys, specifically
 // 'metadata.resourceVersion', 'spec.clusterIP', and any existing
 // entries in a ConfigMap's 'data' field. So we only overwrite fields

--- a/manifestival.go
+++ b/manifestival.go
@@ -24,9 +24,9 @@ type Manifestival interface {
 	// Updates or creates a particular resource
 	Apply(*unstructured.Unstructured) error
 	// Deletes all resources in the manifest
-	DeleteAll(opts ...client.DeleteOptionFunc) error
+	DeleteAll(opts ...client.DeleteOption) error
 	// Deletes a particular resource
-	Delete(spec *unstructured.Unstructured, opts ...client.DeleteOptionFunc) error
+	Delete(spec *unstructured.Unstructured, opts ...client.DeleteOption) error
 	// Returns a copy of the resource from the api server, nil if not found
 	Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error)
 	// Transforms the resources within a Manifest
@@ -91,7 +91,7 @@ func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
 }
 
 // DeleteAll removes all tracked `Resources` in the Manifest.
-func (f *Manifest) DeleteAll(opts ...client.DeleteOptionFunc) error {
+func (f *Manifest) DeleteAll(opts ...client.DeleteOption) error {
 	a := make([]unstructured.Unstructured, len(f.Resources))
 	copy(a, f.Resources)
 	// we want to delete in reverse order
@@ -110,7 +110,7 @@ func (f *Manifest) DeleteAll(opts ...client.DeleteOptionFunc) error {
 
 // Delete removes the specified objects, which do not need to be registered as
 // `Resources` in the Manifest.
-func (f *Manifest) Delete(spec *unstructured.Unstructured, opts ...client.DeleteOptionFunc) error {
+func (f *Manifest) Delete(spec *unstructured.Unstructured, opts ...client.DeleteOption) error {
 	current, err := f.Get(spec)
 	if current == nil && err == nil {
 		return nil

--- a/manifestival_test.go
+++ b/manifestival_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	. "github.com/jcrossley3/manifestival"
+	. "github.com/kabanero-io/manifestival"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/testdata/dangling-symlink/dangling.yaml
+++ b/testdata/dangling-symlink/dangling.yaml
@@ -1,0 +1,1 @@
+not-existing.yaml

--- a/testdata/dangling-symlink/valid.yaml
+++ b/testdata/dangling-symlink/valid.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Foo
+metadata:
+  name: acme
+---
+apiVersion: v1
+kind: Bar
+metadata:
+  name: bazinga

--- a/testdata/hooks.yaml
+++ b/testdata/hooks.yaml
@@ -1,0 +1,16 @@
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    serving.knative.dev/release: devel
+  name: validation.webhook.serving.knative.dev
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  name: validation.webhook.serving.knative.dev

--- a/transform.go
+++ b/transform.go
@@ -54,6 +54,18 @@ func InjectNamespace(ns string) Transformer {
 					m["namespace"] = namespace
 				}
 			}
+		case "validatingwebhookconfiguration", "mutatingwebhookconfiguration":
+			hooks, _, _ := unstructured.NestedFieldNoCopy(u.Object, "webhooks")
+			for _, hook := range hooks.([]interface{}) {
+				m := hook.(map[string]interface{})
+				if c, ok := m["clientConfig"]; ok {
+					cfg := c.(map[string]interface{})
+					if s, ok := cfg["service"]; ok {
+						srv := s.(map[string]interface{})
+						srv["namespace"] = namespace
+					}
+				}
+			}
 		}
 		if !isClusterScoped(u.GetKind()) {
 			u.SetNamespace(namespace)

--- a/transform.go
+++ b/transform.go
@@ -9,15 +9,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// Transform a resource from the manifest
+// Transformer transforms a resource from the manifest in place.
 type Transformer func(u *unstructured.Unstructured) error
 
+// Owner is a partial Kubernetes metadata schema.
 type Owner interface {
 	v1.Object
 	schema.ObjectKind
 }
 
-// If an error occurs, no resources are transformed
+// Transform applies an ordered set of Transformer functions to the
+// `Resources` in this Manifest.  If an error occurs, no resources are
+// transformed.
 func (f *Manifest) Transform(fns ...Transformer) error {
 	var results []unstructured.Unstructured
 	for i := 0; i < len(f.Resources); i++ {
@@ -34,7 +37,9 @@ func (f *Manifest) Transform(fns ...Transformer) error {
 	return nil
 }
 
-// We assume all resources in the manifest live in the same namespace
+// InjectNamespace creates a Transformer which adds a namespace to existing
+// resources if appropriate. We assume all resources in the manifest live in
+// the same namespace.
 func InjectNamespace(ns string) Transformer {
 	namespace := resolveEnv(ns)
 	return func(u *unstructured.Unstructured) error {
@@ -57,6 +62,8 @@ func InjectNamespace(ns string) Transformer {
 	}
 }
 
+// InjectOwner creates a Tranformer which adds an OwnerReference pointing to
+// `owner` to namespace-scoped objects.
 func InjectOwner(owner Owner) Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if !isClusterScoped(u.GetKind()) {

--- a/transform_test.go
+++ b/transform_test.go
@@ -103,3 +103,33 @@ func TestInjectNamespace(t *testing.T) {
 	}
 	assert(f.Resources[1], "food")
 }
+
+func TestInjectNamespaceWebhook(t *testing.T) {
+	assert := func(u unstructured.Unstructured, expected string) {
+		v, _, _ := unstructured.NestedSlice(u.Object, "webhooks")
+		ns, _, err := unstructured.NestedString(v[0].(map[string]interface{}), "clientConfig", "service", "namespace")
+		if err != nil {
+			t.Errorf("Failed to find `clientConfig.service.namespace`: %v", err)
+		}
+		if ns != expected {
+			t.Errorf("Expected %q, got %q", expected, ns)
+		}
+	}
+
+	f, _ := NewManifest("testdata/hooks.yaml", true, nil)
+	if len(f.Resources) != 1 {
+		t.Errorf("Expected 1 resource, got %d", len(f.Resources))
+	}
+	if err := f.Transform(InjectNamespace("foo")); err != nil{
+		t.Error(err)
+	}
+	if len(f.Resources) != 1 {
+		t.Errorf("Expected 1 resource, got %d", len(f.Resources))
+	}
+	assert(f.Resources[0], "foo")
+	os.Setenv("FOO", "food")
+	if err := f.Transform(InjectNamespace("$FOO")); err != nil {
+		t.Error(err)
+	}
+	assert(f.Resources[0], "food")
+}

--- a/transform_test.go
+++ b/transform_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/jcrossley3/manifestival"
+	. "github.com/kabanero-io/manifestival"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -102,4 +102,34 @@ func TestInjectNamespace(t *testing.T) {
 		t.Errorf("Expected namespace name to be food, got %s", f.Resources[0].GetName())
 	}
 	assert(f.Resources[1], "food")
+}
+
+func TestInjectNamespaceWebhook(t *testing.T) {
+	assert := func(u unstructured.Unstructured, expected string) {
+		v, _, _ := unstructured.NestedSlice(u.Object, "webhooks")
+		ns, _, err := unstructured.NestedString(v[0].(map[string]interface{}), "clientConfig", "service", "namespace")
+		if err != nil {
+			t.Errorf("Failed to find `clientConfig.service.namespace`: %v", err)
+		}
+		if ns != expected {
+			t.Errorf("Expected %q, got %q", expected, ns)
+		}
+	}
+
+	f, _ := NewManifest("testdata/hooks.yaml", true, nil)
+	if len(f.Resources) != 1 {
+		t.Errorf("Expected 1 resource, got %d", len(f.Resources))
+	}
+	if err := f.Transform(InjectNamespace("foo")); err != nil{
+		t.Error(err)
+	}
+	if len(f.Resources) != 1 {
+		t.Errorf("Expected 1 resource, got %d", len(f.Resources))
+	}
+	assert(f.Resources[0], "foo")
+	os.Setenv("FOO", "food")
+	if err := f.Transform(InjectNamespace("$FOO")); err != nil {
+		t.Error(err)
+	}
+	assert(f.Resources[0], "food")
 }

--- a/yaml.go
+++ b/yaml.go
@@ -79,12 +79,13 @@ func readDir(pathname string, recursive bool) ([]unstructured.Unstructured, erro
 	aggregated := []unstructured.Unstructured{}
 	for _, f := range list {
 		name := path.Join(pathname, f.Name())
+		pathDirOrFile, _ := os.Stat(name)
 		var els []unstructured.Unstructured
 
 		switch {
-		case f.IsDir() && recursive:
+		case pathDirOrFile.IsDir() && recursive:
 			els, err = readDir(name, recursive)
-		case !f.IsDir():
+		case !pathDirOrFile.IsDir():
 			els, err = readFile(name)
 		}
 

--- a/yaml.go
+++ b/yaml.go
@@ -79,8 +79,12 @@ func readDir(pathname string, recursive bool) ([]unstructured.Unstructured, erro
 	aggregated := []unstructured.Unstructured{}
 	for _, f := range list {
 		name := path.Join(pathname, f.Name())
-		pathDirOrFile, _ := os.Stat(name)
+		pathDirOrFile, err := os.Stat(name)
 		var els []unstructured.Unstructured
+		
+		if os.IsNotExist(err) || os.IsPermission(err) {
+			return aggregated, err
+		}
 
 		switch {
 		case pathDirOrFile.IsDir() && recursive:

--- a/yaml.go
+++ b/yaml.go
@@ -136,6 +136,9 @@ func decode(reader io.Reader) ([]unstructured.Unstructured, error) {
 
 // isURL checks whether or not the given path parses as a URL.
 func isURL(pathname string) bool {
+	if _, err := os.Lstat(pathname); err == nil {
+		return false
+	}
 	url, err := url.ParseRequestURI(pathname)
 	return err == nil && url.Scheme != ""
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -39,6 +39,10 @@ func TestParsing(t *testing.T) {
 		path:      "testdata/missing",
 		wantError: true,
 	}, {
+		name:      "dangling symlink",
+		path:      "testdata/dangling-symlink",
+		wantError: true,
+	}, {
 		name:      "absolute path",
 		path:      filepath.Join(os.Getenv("PWD"), "testdata/tree/dir/b.yaml"),
 		recursive: true,

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -21,30 +21,30 @@ func TestParsing(t *testing.T) {
 		want: []string{"a", "b"},
 	}, {
 		name:      "single directory, recursive",
-		path:      "testdata/tree",
+		path:      filepath.FromSlash("testdata/tree"),
 		recursive: true,
 		want:      []string{"foo", "bar", "baz", "a", "b"},
 	}, {
 		name:      "single file",
-		path:      "testdata/tree/dir/b.yaml",
+		path:      filepath.FromSlash("testdata/tree/dir/b.yaml"),
 		recursive: true,
 		want:      []string{"bar", "baz"},
 	}, {
 		name:      "single file, recursive",
-		path:      "testdata/tree/file.yaml",
+		path:      filepath.FromSlash("testdata/tree/file.yaml"),
 		recursive: true,
 		want:      []string{"a", "b"},
 	}, {
 		name:      "missing file",
-		path:      "testdata/missing",
+		path:      filepath.FromSlash("testdata/missing"),
 		wantError: true,
 	}, {
 		name:      "dangling symlink",
-		path:      "testdata/dangling-symlink",
+		path:      filepath.FromSlash("testdata/dangling-symlink"),
 		wantError: true,
 	}, {
 		name:      "absolute path",
-		path:      filepath.Join(os.Getenv("PWD"), "testdata/tree/dir/b.yaml"),
+		path:      filepath.Join(os.Getenv("PWD"), filepath.FromSlash("testdata/tree/dir/b.yaml")),
 		recursive: true,
 		want:      []string{"bar", "baz"},
 	}, {
@@ -70,7 +70,7 @@ func TestParsing(t *testing.T) {
 		want:      []string{"a", "b", "foo", "bar", "baz"},
 	}, {
 		name:      "file and directory, recursive",
-		path:      "testdata/tree/file.yaml,testdata/tree/dir",
+		path:      filepath.FromSlash("testdata/tree/file.yaml") + "," + filepath.FromSlash("testdata/tree/dir"),
 		recursive: true,
 		want:      []string{"a", "b", "foo", "bar", "baz"},
 	}, {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/jcrossley3/manifestival"
+	. "github.com/kabanero-io/manifestival"
 )
 
 func TestParsing(t *testing.T) {
@@ -21,26 +21,30 @@ func TestParsing(t *testing.T) {
 		want: []string{"a", "b"},
 	}, {
 		name:      "single directory, recursive",
-		path:      "testdata/tree",
+		path:      filepath.FromSlash("testdata/tree"),
 		recursive: true,
 		want:      []string{"foo", "bar", "baz", "a", "b"},
 	}, {
 		name:      "single file",
-		path:      "testdata/tree/dir/b.yaml",
+		path:      filepath.FromSlash("testdata/tree/dir/b.yaml"),
 		recursive: true,
 		want:      []string{"bar", "baz"},
 	}, {
 		name:      "single file, recursive",
-		path:      "testdata/tree/file.yaml",
+		path:      filepath.FromSlash("testdata/tree/file.yaml"),
 		recursive: true,
 		want:      []string{"a", "b"},
 	}, {
 		name:      "missing file",
-		path:      "testdata/missing",
+		path:      filepath.FromSlash("testdata/missing"),
+		wantError: true,
+	}, {
+		name:      "dangling symlink",
+		path:      filepath.FromSlash("testdata/dangling-symlink"),
 		wantError: true,
 	}, {
 		name:      "absolute path",
-		path:      filepath.Join(os.Getenv("PWD"), "testdata/tree/dir/b.yaml"),
+		path:      filepath.Join(os.Getenv("PWD"), filepath.FromSlash("testdata/tree/dir/b.yaml")),
 		recursive: true,
 		want:      []string{"bar", "baz"},
 	}, {
@@ -66,7 +70,7 @@ func TestParsing(t *testing.T) {
 		want:      []string{"a", "b", "foo", "bar", "baz"},
 	}, {
 		name:      "file and directory, recursive",
-		path:      "testdata/tree/file.yaml,testdata/tree/dir",
+		path:      filepath.FromSlash("testdata/tree/file.yaml") + "," + filepath.FromSlash("testdata/tree/dir"),
 		recursive: true,
 		want:      []string{"a", "b", "foo", "bar", "baz"},
 	}, {


### PR DESCRIPTION
Bring Kabanero's fork of Manifestival up to date with upstream.  Upstream was modified to use controller-runtime 0.3.0, and kabanero-operator is in the process of doing the same.